### PR TITLE
[sdk-deploy-rpm] Adapt to PackageKit-Qt 0.9.x. Contributes to JB#15078

### DIFF
--- a/rpm/sdk-deploy-rpm.spec
+++ b/rpm/sdk-deploy-rpm.spec
@@ -12,7 +12,7 @@ License:    BSD
 Source0:    %{name}-%{version}.tar.bz2
 URL:        https://github.com/sailfishos/sdk-deploy-rpm
 BuildRequires:  pkgconfig(Qt5Core)
-BuildRequires:  pkgconfig(packagekit-qt5)
+BuildRequires:  pkgconfig(packagekitqt5)
 
 %description
 Tool to install local RPM packages in Sailfish OS.

--- a/src/deployer.h
+++ b/src/deployer.h
@@ -51,8 +51,6 @@ public slots:
             uint percentage);
     void onFinished(PackageKit::Transaction::Exit status,
             uint runtime);
-    void onMessage(PackageKit::Transaction::Message type,
-            const QString &message);
     void onErrorCode(PackageKit::Transaction::Error error,
                      const QString &details);
     void onPackage(PackageKit::Transaction::Info info,
@@ -60,8 +58,6 @@ public slots:
                    const QString &summary);
 
 private:
-    PackageKit::Transaction *transaction();
-
     PackageKit::Transaction *tx;
 
     enum State {

--- a/src/src.pro
+++ b/src/src.pro
@@ -31,7 +31,7 @@
 QT -= gui
 
 CONFIG += link_pkgconfig
-PKGCONFIG += packagekit-qt5
+PKGCONFIG += packagekitqt5
 
 SOURCES += main.cpp
 


### PR DESCRIPTION
Transaction creation now goes through Daemon interface.
Furthermore Changed signal is removed from PackageKit in favor of
individual property changes. message signal deprecated.

Depends on https://git.merproject.org/mer-core/PackageKit-Qt/merge_requests/4
and https://github.com/hughsie/PackageKit-Qt/pull/16