### PR TITLE
[deploy] Forward installations to installationhandler instead. Fixes JB#48107

### DIFF
--- a/rpm/sdk-deploy-rpm.spec
+++ b/rpm/sdk-deploy-rpm.spec
@@ -12,7 +12,7 @@ License:    BSD
 Source0:    %{name}-%{version}.tar.bz2
 URL:        https://github.com/sailfishos/sdk-deploy-rpm
 BuildRequires:  pkgconfig(Qt5Core)
-BuildRequires:  pkgconfig(packagekitqt5)
+BuildRequires:  pkgconfig(Qt5DBus)
 
 %description
 Tool to install local RPM packages in Sailfish OS.

--- a/src/deployer.cpp
+++ b/src/deployer.cpp
@@ -30,181 +30,47 @@
 
 #include <QCoreApplication>
 #include <QTimer>
+#include <QDBusConnection>
 #include <cstdio>
-
-#include <Daemon>
 
 #include "deployer.h"
 
+static const char * const DBUS_SERVICE = "org.sailfishos.installationhandler";
+static const char * const INSTALLATIONHANDLER_DBUS_PATH = "/org/sailfishos/installationhandler";
+static const char * const DBUS_INTERFACE = "org.sailfishos.installationhandler";
 
-Deployer::Deployer(QStringList rpms, bool verbose)
+Deployer::Deployer(QStringList rpms)
     : QObject(0)
-    , tx(0)
-    , state(INITIAL)
     , rpms(rpms)
-    , verbose_output(verbose)
+    , client(DBUS_SERVICE, INSTALLATIONHANDLER_DBUS_PATH, DBUS_INTERFACE)
+    , watcher(DBUS_SERVICE, client.connection())
 {
+    connect(&client, SIGNAL(installFinished(bool)), this, SLOT(onFinished(bool)));
+    connect(&watcher, &QDBusServiceWatcher::serviceUnregistered, this, &Deployer::onUnregistered);
 }
 
 Deployer::~Deployer()
 {
 }
 
-void
+QDBusReply<void>
 Deployer::run()
 {
-    switch (state) {
-        case INITIAL:
-            if (verbose_output) {
-                fprintf(stderr, "INSTALLING\n");
-            }
-
-            tx = PackageKit::Daemon::installFiles(rpms, PackageKit::Transaction::TransactionFlagNone);
-
-            QObject::connect(tx, SIGNAL(statusChanged()), this, SLOT(onChanged()));
-            QObject::connect(tx, SIGNAL(percentageChanged()), this, SLOT(onChanged()));
-            QObject::connect(tx, SIGNAL(itemProgress(const QString &, PackageKit::Transaction::Status, uint)),
-                             this, SLOT(onItemProgress(const QString &, PackageKit::Transaction::Status, uint)));
-            QObject::connect(tx, SIGNAL(finished(PackageKit::Transaction::Exit, uint)),
-                             this, SLOT(onFinished(PackageKit::Transaction::Exit, uint)));
-            QObject::connect(tx, SIGNAL(errorCode(PackageKit::Transaction::Error, const QString &)),
-                             this, SLOT(onErrorCode(PackageKit::Transaction::Error, const QString &)));
-            QObject::connect(tx, SIGNAL(package(PackageKit::Transaction::Info, const QString &, const QString &)),
-                             this, SLOT(onPackage(PackageKit::Transaction::Info, const QString &, const QString &)));
-
-            state = INSTALLING;
-            break;
-
-        default:
-            break;
-    }
-}
-
-void
-Deployer::onChanged()
-{
-    // this method only prints out progress updates
-    if (!verbose_output) {
-        return;
-    }
-
-    const char *action = "Working";
-
-    switch (tx->status()) {
-        case PackageKit::Transaction::StatusWait:
-            action = "Waiting";
-            break;
-        case PackageKit::Transaction::StatusSetup:
-            action = "Preparing";
-            break;
-        case PackageKit::Transaction::StatusRefreshCache:
-            action = "Refreshing";
-            break;
-        case PackageKit::Transaction::StatusFinished:
-            action = "Finished";
-            break;
-        case PackageKit::Transaction::StatusDownload:
-            action = "Downloading";
-            break;
-        case PackageKit::Transaction::StatusInstall:
-            action = "Installing";
-            break;
-        case PackageKit::Transaction::StatusUpdate:
-            action = "Updating";
-            break;
-        case PackageKit::Transaction::StatusDepResolve:
-            action = "Resolving";
-            break;
-        default:
-            break;
-    }
-
-    fprintf(stderr, "%s", action);
-    if (tx->percentage() != 101) {
-        fprintf(stderr, ": %d%%", tx->percentage());
-    }
-
-    if (tx->remainingTime()) {
-        fprintf(stderr, " (remaining: %ds)", tx->remainingTime());
-    }
-
-    fprintf(stderr, "\n");
-}
-
-void
-Deployer::onItemProgress(const QString &itemID,
-        PackageKit::Transaction::Status status,
-        uint percentage)
-{
-    Q_UNUSED(status);
-
-    // this method only prints out progress updates
-    if (!verbose_output) {
-        return;
-    }
-
-    QStringList id = itemID.split(';');
-    if (id.size() < 2) {
-        id << "";
-    }
-
-    fprintf(stderr, "%s %s: [%d %%]", qPrintable(id[0]), qPrintable(id[1]), percentage);
-    fprintf(stderr, "\n");
+    return client.call("installFiles", rpms);
 }
 
 void 
-Deployer::onFinished(PackageKit::Transaction::Exit status,
-        uint runtime)
+Deployer::onFinished(bool success)
 {
-    fprintf(stderr, "Finished transaction (status=%u, runtime=%ums)\n", status, runtime);
-    tx->deleteLater();
-    tx = NULL;
-
-    state = DONE;
-    if (verbose_output) {
-        fprintf(stderr, "FINISHING\n");
-    }
-    QCoreApplication::exit((status == PackageKit::Transaction::ExitSuccess) ? 0 : 1);
+    fprintf(stderr, "Installation %s.\n", success ? "successful" : "failed");
+    disconnect(&client, SIGNAL(installFinished(bool)), this, SLOT(onFinished(bool)));
+    disconnect(&watcher, &QDBusServiceWatcher::serviceUnregistered, this, &Deployer::onUnregistered);
+    QCoreApplication::exit(success ? 0 : 1);
 }
 
 void
-Deployer::onErrorCode(PackageKit::Transaction::Error error,
-                      const QString &details)
+Deployer::onUnregistered(const QString &)
 {
-    Q_UNUSED(error);
-    fprintf(stderr, "Error: %s\n", qPrintable(details));
-}
-
-void
-Deployer::onPackage(PackageKit::Transaction::Info info,
-                    const QString &id,
-                    const QString &summary)
-{
-    Q_UNUSED(info);
-    Q_UNUSED(summary);
-
-    // in verbose mode similar info has already been printed
-    if (verbose_output) {
-        return;
-    }
-
-    const char *action = "Working";
-
-    switch (tx->status()) {
-        case PackageKit::Transaction::StatusDownload:
-            action = "Downloading";
-            break;
-        case PackageKit::Transaction::StatusInstall:
-            action = "Installing";
-            break;
-        default:
-            break;
-    }
-
-    QStringList pkg = id.split(';');
-    if (pkg.size() < 2) {
-        pkg << "";
-    }
-
-    fprintf(stderr, "%s: %s %s\n", action, qPrintable(pkg[0]), qPrintable(pkg[1]));
+    fprintf(stderr, "Installation failure: service died.\n");
+    QCoreApplication::exit(1);
 }

--- a/src/deployer.h
+++ b/src/deployer.h
@@ -33,41 +33,26 @@
 
 #include <QObject>
 #include <QStringList>
-
-#include <Transaction>
+#include <QDBusReply>
+#include <QDBusInterface>
+#include <QDBusServiceWatcher>
 
 class Deployer : public QObject {
     Q_OBJECT
 
 public:
-    Deployer(QStringList rpms, bool verbose=false);
+    Deployer(QStringList rpms);
     ~Deployer();
+    QDBusReply<void> run();
 
 public slots:
-    void run();
-    void onChanged();
-    void onItemProgress(const QString &itemID,
-            PackageKit::Transaction::Status status,
-            uint percentage);
-    void onFinished(PackageKit::Transaction::Exit status,
-            uint runtime);
-    void onErrorCode(PackageKit::Transaction::Error error,
-                     const QString &details);
-    void onPackage(PackageKit::Transaction::Info info,
-                   const QString &packageID,
-                   const QString &summary);
+    void onFinished(bool success);
+    void onUnregistered(const QString &);
 
 private:
-    PackageKit::Transaction *tx;
-
-    enum State {
-        INITIAL = 0,
-        INSTALLING,
-        DONE,
-    } state;
-
     QStringList rpms;
-    bool verbose_output;
+    QDBusInterface client;
+    QDBusServiceWatcher watcher;
 };
 
 #endif /* DEVEL_DEPLOY_RPM_DEPLOYER_H */

--- a/src/src.pro
+++ b/src/src.pro
@@ -29,9 +29,7 @@
 # 
 
 QT -= gui
-
-CONFIG += link_pkgconfig
-PKGCONFIG += packagekitqt5
+QT += dbus
 
 SOURCES += main.cpp
 


### PR DESCRIPTION
The PackageKit install methods should be limited to only privileged egid callers, so sdk-deploy-rpm needs to call the sailfish-installationhandler daemon with its install requests so it can check sideloading restrictions and prompt the user.